### PR TITLE
PHP的__get()魔法函数在处理数组赋值时出现分配不当问题， 加入引用传递， 使代码更健壮

### DIFF
--- a/protected/lib/speed.php
+++ b/protected/lib/speed.php
@@ -174,7 +174,7 @@ class Controller{
 
 	public function init(){}
 	public function __construct(){$this->init();}
-	public function __get($name){return $this->_data[$name];}
+	public function &__get($name){return $this->_data[$name];}
 	public function __set($name, $value){$this->_data[$name] = $value;}
 	
 	public function display($tpl_name, $return = false){


### PR DESCRIPTION
https://bugs.php.net/bug.php?id=42030