### PR TITLE
增加模板中的url方法m和c 分开赋值时， url能够正确识别m参数

### DIFF
--- a/protected/lib/speed.php
+++ b/protected/lib/speed.php
@@ -91,7 +91,12 @@ if($controller_obj->_auto_display){
 function url($c = 'main', $a = 'index', $param = array()){
 	if(is_array($c)){
 		$param = $c;
-		$c = $param['c']; unset($param['c']);
+		if(isset($param['m'])) {
+                    $c = $param['m'] . '/' . $param['c'];
+                    unset($param['m'], $param['c']);
+                } else {
+                    $c = $param['c']; unset($param['c']);
+                }
 		$a = $param['a']; unset($param['a']);
 	}
 	$params = empty($param) ? '' : '&'.http_build_query($param);


### PR DESCRIPTION
在模板中有时会需要这样的使用url方法： <{url m=$m c=$c a=$a}>或 <{url m='demo' c=$c a=$a}> 等情形时，url方法会将m参数放入到$params里，现url增加m和c分开赋值情形的判断，使其在开启伪静态后能够正确识别m参数