### PR TITLE
where语句支持string类型的condition

### DIFF
--- a/protected/lib/speed.php
+++ b/protected/lib/speed.php
@@ -363,6 +363,9 @@ class Model{
 
 			$result["_where"] = " WHERE ". $sql;
 			$result["_bindParams"] = $conditions;
+		} else if(is_string($conditions) && !empty($conditions)){
+			$result["_where"] = " WHERE ". $conditions;
+			$result["_bindParams"] = array();
 		}
 		return $result;
 	}


### PR DESCRIPTION
在findAll时，需要用到分页和condition的组合，但是condition现在不支持复杂的查询方式。
where语句支持string类型的condition，对于之前版本也能够更容易的迁移。